### PR TITLE
Update to 0.18.0

### DIFF
--- a/_extensions/julia-engine/Project.toml
+++ b/_extensions/julia-engine/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.17.4"
+QuartoNotebookRunner = "=0.18.0"


### PR DESCRIPTION
## QuartoNotebookRunner 0.18.0

### Features

- **Shared worker processes**: Multiple notebooks can now run on a single worker process if their worker configs match (executable, flags, env, strict_manifest_versions). Enable with `share_worker_process: true` in frontmatter. State is isolated per notebook via task-local storage, so multiple notebooks render concurrently on one worker. Workers are ref-counted and recover automatically if the process dies. RNG state is also isolated per notebook, so results stay reproducible regardless of rendering order.

- **`execute-dir` support**: Quarto's `execute-dir` option is passed through, so `execute-dir: project` in `_quarto.yml` works as expected.

- **`QUARTO_PROJECT_ROOT` refresh**: Previously stuck at the first value for the lifetime of the server. Now updates per render, so notebooks from different projects get the right root.

- **Diagnostic file logging**: Set `QUARTONOTEBOOKRUNNER_LOG` to a directory path. Host and worker processes write timestamped logs to separate files there.

### Performance

- **Cached worker environments**: Worker envs are persisted across sessions via Scratch.jl. If Julia version and QNR version haven't changed, startup skips environment setup entirely.

- **Expanded precompile workloads**: Both worker and host precompile more code paths (render, IPC serialization), cutting time to first render after installation.

### Fixes

- **Relaxed manifest version checking**: Defaults now match Julia's Pkg: only major.minor is checked. The old strict major.minor.patch behavior is opt-in via `julia: strict_manifest_versions: true` in frontmatter.

- **`run!` swallowing exceptions**: `run!` was checking `isrunning` before fetching the task result, which would mask real exceptions. Now only checks after fetch.

- **Echo handling for Python/R cells**: Fixed duplicate YAML keys when Python/R cells have user-specified options like `echo`. Also adds proper support for `echo: false` (hide code) and `echo: fenced` (show fence markers) in Python/R cells.

- **Package hook error handling**: Errors in loading/refresh/post-eval/post-error hooks are caught and reported via `@warn` instead of silently hanging the worker.

- **Worker env cache invalidation**: The worker environment cache key now includes a content hash of QuartoNotebookWorker's Project.toml. Before this, only the QNR version was used, so adding a dependency wouldn't invalidate the cache.

### Internal

- **Binary IPC protocol**: Malt + BSON replaced with custom binary serialization over direct sockets. Drops the BSON dependency, gives type-stable dispatch via parametric `PendingCall{R}` with typed channels.

- **Single-task evaluation**: Cell evaluation no longer spawns separate tasks.