### PR TITLE
feat: Add keep-ipynb support

### DIFF
--- a/_extensions/julia-engine/julia-engine.js
+++ b/_extensions/julia-engine/julia-engine.js
@@ -631,6 +631,7 @@ var kFigFormat = "fig-format";
 var kFigPos = "fig-pos";
 var kIpynbProduceSourceNotebook = "produce-source-notebook";
 var kKeepHidden = "keep-hidden";
+var kKeepIpynb = "keep-ipynb";
 
 // src/julia-engine.ts
 var isWindows2 = Deno.build.os === "windows";
@@ -749,6 +750,11 @@ var juliaEngineDiscovery = {
           language: "julia"
         };
         const assets = quarto.jupyter.assets(options.target.input, options.format.pandoc.to);
+        if (options.format.execute[kKeepIpynb]) {
+          const stem = options.target.source.replace(/\.[^.]+$/, "");
+          const ipynbPath = stem + ".ipynb";
+          Deno.writeTextFileSync(ipynbPath, JSON.stringify(nb, null, 2));
+        }
         const result = await quarto.jupyter.toMarkdown(nb, {
           executeOptions: options,
           language: nb.metadata.kernelspec.language.toLowerCase(),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,4 @@ export const kFigFormat = "fig-format";
 export const kFigPos = "fig-pos";
 export const kIpynbProduceSourceNotebook = "produce-source-notebook";
 export const kKeepHidden = "keep-hidden";
+export const kKeepIpynb = "keep-ipynb";

--- a/src/julia-engine.ts
+++ b/src/julia-engine.ts
@@ -37,6 +37,7 @@ import {
   kIpynbProduceSourceNotebook,
   kJuliaEngine,
   kKeepHidden,
+  kKeepIpynb,
 } from "./constants.ts";
 
 // Platform detection
@@ -219,6 +220,14 @@ export const juliaEngineDiscovery: ExecutionEngineDiscovery = {
           options.target.input,
           options.format.pandoc.to,
         );
+
+        // Write notebook to file if keep-ipynb is set (must happen before
+        // toMarkdown which mutates nb in place)
+        if (options.format.execute[kKeepIpynb]) {
+          const stem = options.target.source.replace(/\.[^.]+$/, "");
+          const ipynbPath = stem + ".ipynb";
+          Deno.writeTextFileSync(ipynbPath, JSON.stringify(nb, null, 2));
+        }
 
         // NOTE: for perforance reasons the 'nb' is mutated in place
         // by jupyterToMarkdown (we don't want to make a copy of a

--- a/tests/docs/julia-engine/keep-ipynb/keep-ipynb.qmd
+++ b/tests/docs/julia-engine/keep-ipynb/keep-ipynb.qmd
@@ -1,0 +1,10 @@
+---
+title: keep-ipynb test
+engine: julia
+format: html
+keep-ipynb: true
+---
+
+```{julia}
+1 + 1
+```

--- a/tests/docs/julia-engine/keep-ipynb/no-keep-ipynb.qmd
+++ b/tests/docs/julia-engine/keep-ipynb/no-keep-ipynb.qmd
@@ -1,0 +1,9 @@
+---
+title: no keep-ipynb test
+engine: julia
+format: html
+---
+
+```{julia}
+1 + 1
+```

--- a/tests/smoke/julia-engine/render.test.ts
+++ b/tests/smoke/julia-engine/render.test.ts
@@ -44,6 +44,40 @@ Deno.test("source ranges with includes", async () => {
   try { Deno.removeSync(outputFile); } catch { /* ok */ }
 });
 
+Deno.test("keep-ipynb", async () => {
+  const dir = docs("julia-engine/keep-ipynb");
+  const input = join(dir, "keep-ipynb.qmd");
+  renderQmd(input, ["--to", "html"]);
+
+  const outputHtml = join(dir, "keep-ipynb.html");
+  assert(existsSync(outputHtml), `Output file ${outputHtml} should exist`);
+
+  const ipynbFile = join(dir, "keep-ipynb.ipynb");
+  assert(existsSync(ipynbFile), `keep-ipynb file ${ipynbFile} should exist`);
+
+  const content = await Deno.readTextFile(ipynbFile);
+  const nb = JSON.parse(content);
+  assert(nb.cells, "Notebook should have cells");
+  assert(nb.metadata, "Notebook should have metadata");
+
+  try { Deno.removeSync(outputHtml); } catch { /* ok */ }
+  try { Deno.removeSync(ipynbFile); } catch { /* ok */ }
+});
+
+Deno.test("no keep-ipynb by default", () => {
+  const dir = docs("julia-engine/keep-ipynb");
+  const input = join(dir, "no-keep-ipynb.qmd");
+  renderQmd(input, ["--to", "html"]);
+
+  const outputHtml = join(dir, "no-keep-ipynb.html");
+  assert(existsSync(outputHtml), `Output file ${outputHtml} should exist`);
+
+  const ipynbFile = join(dir, "no-keep-ipynb.ipynb");
+  assert(!existsSync(ipynbFile), `ipynb file ${ipynbFile} should NOT exist without keep-ipynb`);
+
+  try { Deno.removeSync(outputHtml); } catch { /* ok */ }
+});
+
 Deno.test("engine reordering", () => {
   const dir = docs("julia-engine/engine-reordering");
   renderQmd("notebook.qmd", ["--to", "html"], dir);


### PR DESCRIPTION
## Summary

- Add `keep-ipynb` option support to the Julia engine. When `keep-ipynb: true` is set in the document YAML, the executed notebook is written to `<stem>.ipynb` alongside the source file.
- The write happens before `toMarkdown()` mutates the notebook in place, so the saved notebook contains the full execution results.

## How these changes were tested

- Added test `keep-ipynb` that renders a `.qmd` with `keep-ipynb: true` and verifies the `.ipynb` file is produced with valid notebook structure.
- Added test `no keep-ipynb by default` that renders without the option and verifies no `.ipynb` file is created.
- All 4 render tests pass locally.

Created with the help of [Claude Code](https://claude.com/claude-code)