### PR TITLE
docs: add CHANGELOG and enforce-changelog workflow

### DIFF
--- a/.github/workflows/EnforceChangelog.yml
+++ b/.github/workflows/EnforceChangelog.yml
@@ -1,0 +1,14 @@
+name: "Enforce changelog"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3.6.1
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabels: 'skip-changelog'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,7 @@ CI runs on all three platforms (Linux, macOS, Windows) against a pinned quarto-c
 3. Runs the full test suite
 
 When bumping `QUARTO_CLI_REV`, use the full commit hash annotated with the version tag for clarity (e.g. `abc123 # v1.9.35`).
+
+## Changelog
+
+Every PR with user-facing or otherwise meaningful changes must include an update to `CHANGELOG.md` (enforced by CI). Add entries under the `## Unreleased` section. Use the `skip-changelog` label to bypass the check for PRs that don't need an entry (e.g. internal cleanups, CI, or docs changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Quarto Julia Engine changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- Added `keep-ipynb` support. When `keep-ipynb: true` is set in document YAML, the executed notebook is written to `<stem>.ipynb` alongside the source file [#8](https://github.com/PumasAI/quarto-julia-engine/pull/8).
+- Updated to QuartoNotebookRunner 0.18.0 [#7](https://github.com/PumasAI/quarto-julia-engine/pull/7):
+  - **Shared worker processes**: Multiple notebooks can share a single worker process when their configs match. Enable with `share_worker_process: true`.
+  - **`execute-dir` support**: Quarto's `execute-dir` option (e.g. `execute-dir: project`) is now passed through correctly.
+  - **Cached worker environments**: Worker envs persist across sessions, skipping environment setup on subsequent runs when Julia and QNR versions haven't changed.
+  - **Relaxed manifest version checking**: Only major.minor is checked by default, matching Julia's Pkg behavior. Opt into strict major.minor.patch via `julia: strict_manifest_versions: true`.
+  - **Diagnostic file logging**: Set `QUARTONOTEBOOKRUNNER_LOG` to a directory path to enable timestamped log files.
+  - **Echo handling for Python/R cells**: Fixed duplicate YAML keys and added proper support for `echo: false` and `echo: fenced`.
+
+## [0.1.0](https://github.com/PumasAI/quarto-julia-engine/releases/tag/v0.1.0) - 2026-03-19
+
+- Initial release as a standalone Quarto extension, extracted from [quarto-cli](https://github.com/quarto-dev/quarto-cli).
+- Bundled Julia resource files (`Project.toml`, `ensure_environment.jl`, `quartonotebookrunner.jl`, `start_quartonotebookrunner_detached.jl`) into the extension, making it fully self-contained [#6](https://github.com/PumasAI/quarto-julia-engine/pull/6).
+- Added CI workflow with tests on Linux, macOS, and Windows [#6](https://github.com/PumasAI/quarto-julia-engine/pull/6).

--- a/tests/docs/julia-engine/.gitignore
+++ b/tests/docs/julia-engine/.gitignore
@@ -4,3 +4,4 @@
 # Allow only source files
 !*/*.qmd
 !*/_quarto.yml
+!*/_metadata.yml

--- a/tests/docs/julia-engine/engine-reordering/_metadata.yml
+++ b/tests/docs/julia-engine/engine-reordering/_metadata.yml
@@ -1,0 +1,1 @@
+engines: ["julia"]

--- a/tests/docs/julia-engine/engine-reordering/_quarto.yml
+++ b/tests/docs/julia-engine/engine-reordering/_quarto.yml
@@ -1,3 +1,0 @@
-project:
-  type: default
-engines: ["julia"]

--- a/tests/docs/julia-engine/sleep/_quarto.yml
+++ b/tests/docs/julia-engine/sleep/_quarto.yml
@@ -1,2 +1,0 @@
-project:
-  type: default


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` covering all changes since the initial 0.1.0 release (PRs #6–#8), with an `Unreleased` section for the upcoming 0.2.0 tag.
- Add `EnforceChangelog.yml` GitHub Actions workflow that requires `CHANGELOG.md` to be updated on every PR. PRs labeled `skip-changelog` bypass the check.
- Add changelog section to `AGENTS.md` documenting the requirement.
- Fix test extension discovery: remove per-test-directory `_quarto.yml` files that created independent project roots, preventing quarto from finding the repo root's `_extensions/julia-engine/`. Convert `engine-reordering/_quarto.yml` to `_metadata.yml` so its `engines` setting is inherited without blocking project root traversal. This was causing Windows CI to use quarto-cli's built-in engine (with QNR 0.17.4) instead of the extension's (QNR 0.18.0).

## How these changes were tested

- CI passes on all three platforms (Linux, macOS, Windows) with and without caching.
- Verified `_metadata.yml` correctly propagates the `engines` setting in a temporary quarto project.

Created with the help of [Claude Code](https://claude.com/claude-code)