### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.0](https://github.com/PumasAI/quarto-julia-engine/releases/tag/v0.2.0) - 2026-03-24
+
 - Added `keep-ipynb` support. When `keep-ipynb: true` is set in document YAML, the executed notebook is written to `<stem>.ipynb` alongside the source file [#8](https://github.com/PumasAI/quarto-julia-engine/pull/8).
-- Updated to QuartoNotebookRunner 0.18.1:
+- Updated to QuartoNotebookRunner 0.18.1 [#11](https://github.com/PumasAI/quarto-julia-engine/pull/11):
   - **`fig-format: retina` support**: Normalized to `png` with doubled `fig-dpi`, matching Quarto's Jupyter and knitr backends. Fixes blurry plots with default HTML settings.
   - **Improved cache invalidation**: Cache key now hashes full `Manifest.toml` content (SHA-224) so dependency version changes correctly invalidate the cache.
 - Updated to QuartoNotebookRunner 0.18.0 [#7](https://github.com/PumasAI/quarto-julia-engine/pull/7):

--- a/_extensions/julia-engine/_extension.yml
+++ b/_extensions/julia-engine/_extension.yml
@@ -1,5 +1,5 @@
 title: Quarto Julia Engine Extension
-version: 0.1.0
+version: 0.2.0
 quarto-required: ">=1.9.0"
 contributes:
   engines:


### PR DESCRIPTION
## Summary

- Bump extension version in `_extension.yml` from 0.1.0 to 0.2.0.
- Move changelog entries from `Unreleased` to `0.2.0`.

Created with the help of [Claude Code](https://claude.com/claude-code)